### PR TITLE
remove tables from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ notebook
 numpy
 pandas
 pydot
-tables
 graphviz


### PR DESCRIPTION
`tables` is an optional dependency that makes it difficult to install `ml_workflow` in some environments.

Closes #1